### PR TITLE
feat: 채팅 말풍선 구현

### DIFF
--- a/src/components/Chat/ChatBubble.module.css
+++ b/src/components/Chat/ChatBubble.module.css
@@ -1,7 +1,4 @@
 .wrapper {
-  min-width: 91px;
-  min-height: 40px;
-  max-width: 255px;
   word-wrap: break-word;
   margin-bottom: 20px;
   line-height: 24px;
@@ -16,6 +13,7 @@
   display: inline-block;
   margin: 15px;
   padding: 12px 16px;
+  max-width: 255px;
   background: var(--color-brand2);
   border-radius: 20px;
   color: white;
@@ -23,9 +21,9 @@
 }
 
 .fromMe:after {
-  content: "";
+  content: '';
   position: absolute;
-  top: 20px;
+  top: 12px;
   right: -10px;
   border-top: 15px solid var(--color-brand2);
   border-left: 0 solid transparent;
@@ -35,13 +33,17 @@
 
 .fromMe p {
   margin: 0;
+  font-size: 14px;
+  font-weight: var(--font-weight-bold);
 }
 
 .fromThem {
+  line-height: 24px;
   position: relative;
   display: inline-block;
   margin: 15px;
   padding: 12px 16px;
+  max-width: 255px;
   background: var(--color-gray2);
   border-radius: 20px;
   color: black;
@@ -49,9 +51,9 @@
 }
 
 .fromThem:after {
-  content: "";
+  content: '';
   position: absolute;
-  top: 20px;
+  top: 12px;
   left: -10px;
   border-top: 15px solid var(--color-gray2);
   border-left: 15px solid transparent;
@@ -61,4 +63,6 @@
 
 .fromThem p {
   margin: 0;
+  font-size: 14px;
+  font-weight: var(--font-weight-bold);
 }

--- a/src/components/Chat/ChatBubble.module.css
+++ b/src/components/Chat/ChatBubble.module.css
@@ -1,0 +1,64 @@
+.wrapper {
+  min-width: 91px;
+  min-height: 40px;
+  max-width: 255px;
+  word-wrap: break-word;
+  margin-bottom: 20px;
+  line-height: 24px;
+}
+
+.clear {
+  clear: both;
+}
+
+.fromMe {
+  position: relative;
+  display: inline-block;
+  margin: 15px;
+  padding: 12px 16px;
+  background: var(--color-brand2);
+  border-radius: 20px;
+  color: white;
+  float: right;
+}
+
+.fromMe:after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: -10px;
+  border-top: 15px solid var(--color-brand2);
+  border-left: 0 solid transparent;
+  border-right: 15px solid transparent;
+  border-bottom: 0 solid transparent;
+}
+
+.fromMe p {
+  margin: 0;
+}
+
+.fromThem {
+  position: relative;
+  display: inline-block;
+  margin: 15px;
+  padding: 12px 16px;
+  background: var(--color-gray2);
+  border-radius: 20px;
+  color: black;
+  float: left;
+}
+
+.fromThem:after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  left: -10px;
+  border-top: 15px solid var(--color-gray2);
+  border-left: 15px solid transparent;
+  border-right: 0 solid transparent;
+  border-bottom: 0 solid transparent;
+}
+
+.fromThem p {
+  margin: 0;
+}

--- a/src/components/Chat/ChatBubble.tsx
+++ b/src/components/Chat/ChatBubble.tsx
@@ -12,10 +12,9 @@ export default function ChatBubble({
   variant = 'them',
 }: ChatBubbleProps) {
   const variantStyle = variant === 'me' ? styles.fromMe : styles.fromThem;
-
   return (
     <>
-      <div className={`${variantStyle}` + (className ?? '')}>
+      <div className={`${variantStyle} ${className || ''}`.trim()}>
         {typeof children === 'string' ? <p>{children}</p> : children}
       </div>
       <div className={styles.clear} />

--- a/src/components/Chat/ChatBubble.tsx
+++ b/src/components/Chat/ChatBubble.tsx
@@ -1,0 +1,22 @@
+import styles from './ChatBubble.module.css';
+
+interface ChatBubbleProps {
+  children: React.ReactNode;
+  variant?: 'me' | 'them';
+}
+
+export default function ChatBubble({
+  children,
+  variant = 'them',
+}: ChatBubbleProps) {
+  const className = variant === 'me' ? styles.fromMe : styles.fromThem;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={className}>
+        {typeof children === 'string' ? <p>{children}</p> : children}
+      </div>
+      <div className={styles.clear} />
+    </div>
+  );
+}

--- a/src/components/Chat/ChatBubble.tsx
+++ b/src/components/Chat/ChatBubble.tsx
@@ -1,22 +1,24 @@
 import styles from './ChatBubble.module.css';
 
 interface ChatBubbleProps {
+  className?: string;
   children: React.ReactNode;
   variant?: 'me' | 'them';
 }
 
 export default function ChatBubble({
   children,
+  className,
   variant = 'them',
 }: ChatBubbleProps) {
-  const className = variant === 'me' ? styles.fromMe : styles.fromThem;
+  const variantStyle = variant === 'me' ? styles.fromMe : styles.fromThem;
 
   return (
-    <div className={styles.wrapper}>
-      <div className={className}>
+    <>
+      <div className={`${variantStyle}` + (className ?? '')}>
         {typeof children === 'string' ? <p>{children}</p> : children}
       </div>
       <div className={styles.clear} />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

채팅 말풍선을 구현했습니다. 본인이 보낸 메시지, 상대가 보낸 메시지를 variant로 처리할 수 있고, className에 따라 커스텀 스타일을 줄 수 있게 구현했습니다.
 
### 스크린샷 또는 구동 연상(선택) 

<img width="471" height="734" alt="스크린샷 2026-06-08 오전 9 58 32" src="https://github.com/user-attachments/assets/2459b72b-2ce0-4a50-a332-6b005e1d2aa1" />
